### PR TITLE
ppxlib make it work again

### DIFF
--- a/bin/Bin.re
+++ b/bin/Bin.re
@@ -1,3 +1,3 @@
 open Ppxlib;
 
-let _ = Driver.standalone();
+let _ = Driver.run_as_ppx_rewriter();

--- a/copyPlatformBinaryInPlace.js
+++ b/copyPlatformBinaryInPlace.js
@@ -8,7 +8,7 @@ var platform = process.platform === "win32" ? "win" : process.platform;
 
 var rootDir = __dirname;
 var sourceExePath = path.join(rootDir, `bs-let-${platform}-${arch}.exe`);
-var destExePath = path.join(rootDir, `ppx${platform == "win" ? : ".exe": ""}`);
+var destExePath = path.join(rootDir, `ppx${platform === "win" ? ".exe": ""}`);
 
 copyBinary(sourceExePath, destExePath);
 

--- a/src/Let_anything.re
+++ b/src/Let_anything.re
@@ -16,12 +16,6 @@ let mkloc = (txt, loc) => {
   {Location.txt, loc};
 };
 
-let lid_last = fun
-  | Lident(s) => s
-  | Ldot(_, s) => s
-  | Lapply(_, _) => failwith("lid_last on functor application")
-
-
 let rec process_bindings = (bindings, ident) =>
   Parsetree.(
     switch (bindings) {
@@ -80,7 +74,7 @@ class mapper = {
         ]),
       )) =>
       let ident = parseLongident(txt);
-      let last = lid_last(ident);
+      let last = Longident.last_exn(ident);
       if (last != String.capitalize_ascii(last)) {
         super#expression(expr);
       } else {
@@ -116,7 +110,7 @@ class mapper = {
         ]),
       )) =>
       let ident = parseLongident(txt);
-      let last = lid_last(ident);
+      let last = Longident.last_exn(ident);
       if (last != String.capitalize_ascii(last)) {
         super#expression(expr);
       } else {

--- a/src/Let_anything.re
+++ b/src/Let_anything.re
@@ -116,18 +116,18 @@ class mapper = {
       } else {
         let (pat, expr) = process_bindings(bindings, ident);
         let let_ =
-          Ast_helper.Exp.ident(
+          Ast_builder.Default.pexp_ident(
             ~loc,
             mkloc(Longident.Ldot(ident, "let_"), loc),
           );
-        Ast_helper.Exp.apply(
+        Ast_builder.Default.pexp_apply(
           ~loc,
           let_,
           [
             (Nolabel, self#expression(expr)),
             (
               Nolabel,
-              Ast_helper.Exp.fun_(
+              Ast_builder.Default.pexp_fun(
                 ~loc,
                 Nolabel,
                 None,

--- a/src/Let_anything.re
+++ b/src/Let_anything.re
@@ -54,7 +54,7 @@ let parseLongident = txt => {
 };
 
 class mapper = {
-  as _;
+  as self;
   inherit class Ast_traverse.map as super;
 
   pub! expression = expr => {
@@ -91,7 +91,7 @@ class mapper = {
           ~loc,
           try_,
           [
-            (Nolabel, super#expression(value)),
+            (Nolabel, self#expression(value)),
             (Nolabel, Ast_helper.Exp.function_(~loc=handlerLoc, handlers)),
           ],
         );
@@ -124,7 +124,7 @@ class mapper = {
           ~loc,
           let_,
           [
-            (Nolabel, super#expression(expr)),
+            (Nolabel, self#expression(expr)),
             (
               Nolabel,
               Ast_helper.Exp.fun_(
@@ -132,7 +132,7 @@ class mapper = {
                 Nolabel,
                 None,
                 pat,
-                super#expression(continuation),
+                self#expression(continuation),
               ),
             ),
           ],


### PR DESCRIPTION
Here are some changes I did to have it compiling on Mac M1 and working on my code base. Not all of them are mandatory. For example, the usage of `Ast_builder` instead of `Ast_helper` is not necessary to have it working, and similarly for the usage of `Longident.last_exn`.